### PR TITLE
feat: enable database seeder execution in command.go

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -33,10 +33,10 @@ func Commands(db *gorm.DB) bool {
 	}
 
 	if seed {
-		//if err := migration.Seeder(db); err != nil {
-		//	log.Fatalf("error migration seeder: %v", err)
-		//}
-		//log.Println("seeder completed successfully")
+		if err := migration.Seeder(db); err != nil {
+			log.Fatalf("error migration seeder: %v", err)
+		}
+		log.Println("seeder completed successfully")
 	}
 
 	if run {

--- a/infrastructure/database/migration/data/category.go
+++ b/infrastructure/database/migration/data/category.go
@@ -1,0 +1,33 @@
+package data
+
+import "givebox/infrastructure/database/donation/category"
+
+var Categories = []category.Category{
+	{
+		Name: "Pakaian & Aksesoris",
+	},
+	{
+		Name: "Elektronik",
+	},
+	{
+		Name: "Buku & Pendidikan",
+	},
+	{
+		Name: "Rumah Tangga",
+	},
+	{
+		Name: "Mainan & Permainan",
+	},
+	{
+		Name: "Furnitur",
+	},
+	{
+		Name: "Olahraga & Rekreasi",
+	},
+	{
+		Name: "Barang Bayi & Anak",
+	},
+	{
+		Name: "Lainnya",
+	},
+}

--- a/infrastructure/database/migration/seeder.go
+++ b/infrastructure/database/migration/seeder.go
@@ -1,0 +1,14 @@
+package migration
+
+import (
+	"givebox/infrastructure/database/migration/seeds"
+	"gorm.io/gorm"
+)
+
+func Seeder(db *gorm.DB) error {
+	if err := seeds.Category(db); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/infrastructure/database/migration/seeds/category.go
+++ b/infrastructure/database/migration/seeds/category.go
@@ -1,0 +1,24 @@
+package seeds
+
+import (
+	"givebox/infrastructure/database/donation/category"
+	"givebox/infrastructure/database/migration/data"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func Category(db *gorm.DB) error {
+	hasTable := db.Migrator().HasTable(&category.Category{})
+	if !hasTable {
+		if err := db.Migrator().CreateTable(&category.Category{}); err != nil {
+			return err
+		}
+	}
+
+	return db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "name"},
+		},
+		UpdateAll: true,
+	}).CreateInBatches(data.Categories, 100).Error
+}


### PR DESCRIPTION
This pull request introduces functionality for seeding initial category data into the database, including the implementation of a seeder mechanism, predefined category data, and updates to the command logic to enable seeding. Below are the most important changes grouped by theme:

### Seeder Mechanism Implementation:
* Added a `Seeder` function in `infrastructure/database/migration/seeder.go` to handle the execution of seed data operations, starting with categories. This function ensures modular and reusable seeding logic.

### Category Data and Seeding Logic:
* Created a `Categories` variable in `infrastructure/database/migration/data/category.go` containing predefined category data, such as "Pakaian & Aksesoris" and "Elektronik." This data will be used for populating the database.
* Implemented a `Category` seeding function in `infrastructure/database/migration/seeds/category.go` that creates the `Category` table if it doesn’t exist and inserts the predefined category data using the `gorm` ORM. The function uses the `OnConflict` clause to handle duplicate entries gracefully.

### Command Logic Update:
* Updated the `Commands` function in `command/command.go` to enable the seeding process by uncommenting and refining the call to the `Seeder` function. This ensures the seeding process is executed when the appropriate flag is set.

Closes #7 